### PR TITLE
Remove server reporting, fixes for poltergeist

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,38 +6,26 @@ accesslint.js warns you of accessibility errors in your website.
 
 ## Usage
 
-Download the [latest release](https://github.com/accesslint/accesslint.js/releases/latest) and
-include the javascript in your page:
+Download the
+[latest release](https://github.com/accesslint/accesslint.js/releases/latest)
+and include the javascript in your page at the end of the `<body>` tag.
 
 ```
 <script src="accesslint.js" type="text/javascript">
 ```
 
+Open the page and watch your browser's JavaScript console for warnings.
+
 ## How it works
-
-When a visitor arrives at a page that has the script installed, an audit will
-run in the background automatically. If there are any accessibility issues on
-that page, accesslint.js will log the error to the console, and post to a server
-endpoint that you can optionally configure.
-
-The audit will run once on page load, and **again for each DOM change event.**
-This feature gives you feedback on new content introduced via AJAX, for example.
 
 accesslint.js runs assertions from the
 [aXe-core](https://github.com/dequelabs/axe-core) accessibility library wherever
-you include the script. It the logs the violations the browser's Javascript
-console. It also POSTs the results to `/access_lint/errors` in your app. If you
-set up and endpoint with that path, you can log the errors on the server too.
-See [AccessLint::Rails](https://github.com/thoughtbot/access_lint-rails) for a
-Rails implementation of server side logging of accessibility errors.
+you include the script once on page load, and again for each DOM change event.
 
-![animated screencapture of accesslint warnings to the console](https://cloud.githubusercontent.com/assets/108163/15450990/693ce7e4-1f7c-11e6-8778-6a6aced77679.gif)
-
+This feature gives you feedback on new content introduced via AJAX, for example,
+or updates to a single page app.
 
 ## Development
-
-AccessLint Monitor uses babel and webpack to transpile and package ES2015
-code for inclusion clientside. It uses karma and mocha to run tests.
 
 ### Setup
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "request": "~2.61.0",
     "sinon": "git://github.com/cjohansen/Sinon.JS#b672042043517b9f84e14ed0fb8265126168778a",
     "sinon-chai": "^2.8.0",
+    "underscore": "^1.8.3",
     "webpack": "^1.12.9"
   },
   "dependencies": {

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,24 +1,20 @@
+import _ from "underscore";
+
 export default class Logger {
   constructor() {
     this.logged = []
   }
 
   warn(violation) {
-    if(!this.exists(violation)) {
-      console.warn(violation);
+    if(!this.seen(violation)) {
+      window.console.warn(violation.help, violation.nodes);
       this.logged.push(violation);
     }
   }
 
-  exists(violation) {
-    let exists = false;
-
-    this.logged.forEach(function(entry) {
-      if (JSON.stringify(entry) === JSON.stringify(violation)) {
-        exists = true;
-      }
+  seen(violation) {
+    return _.any(this.logged, function(message) {
+      return _.isEqual(message, violation)
     });
-
-    return exists;
   }
 }

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,9 +1,4 @@
-import request from "browser-request";
-
-const url = "/access_lint/errors";
-
 export default function(message, logger) {
-
   var violations = message.violations.map(function(violation) {
     return {
       description: violation.description,
@@ -15,20 +10,7 @@ export default function(message, logger) {
     };
   });
 
-  if (violations.length > 0) {
-    request({
-      method: "POST",
-      url: url,
-      json: {
-        accesslint: {
-          violations: violations,
-          url: window.location.pathname
-        }
-      }
-    }, function() {});
-
-    violations.forEach(function(violation) {
-      logger.warn(violation);
-    });
-  }
+  violations.forEach(function(violation) {
+    logger.warn(violation);
+  });
 }

--- a/test/unit/logger_test.js
+++ b/test/unit/logger_test.js
@@ -10,10 +10,11 @@ describe("warn", () => {
   it("logs to console.warn", () => {
     let logger = new Logger();
     sinon.spy(console, "warn");
-    logger.warn("example");
-    logger.warn("example");
 
-    expect(console.warn).to.be.have.been.calledWith("example");
+    logger.warn({ help: "example", nodes: []});
+    logger.warn({ help: "example", nodes: []});
+
+    expect(console.warn).to.be.have.been.calledWith("example", []);
     expect(console.warn).to.be.have.been.calledOnce;
   });
 });


### PR DESCRIPTION
- Do not POST to /access_lint/errors. This should be a configuration
  option eventually.
- Log violation message in a format that poltergeist webdriver can
  handle.
- Check deep equality of the violation messages with underscore
  (JSON.stringify was failing in poltergeist).
- Update Readme.

Running Rails capybara specs with poltergeist will render the warning to stdout:

```
% bundle exec rspec spec/features

Randomized with seed 35702
<html> element must have a valid lang attribute [object HTMLHtmlElement]
Form elements must have labels [object HTMLInputElement]
.

Finished in 2.18 seconds (files took 1.11 seconds to load)
1 example, 0 failures

Randomized with seed 35702
```

Safari, Chrome, and Firefox consoles behave as expected:

![screen shot 2016-05-21 at 8 21 42 pm](https://cloud.githubusercontent.com/assets/108163/15451467/c36dd858-1f91-11e6-9c5f-7a945c7b38f7.png)
![screen shot 2016-05-21 at 8 20 58 pm](https://cloud.githubusercontent.com/assets/108163/15451469/c395752a-1f91-11e6-8419-a9f858271e62.png)
![screen shot 2016-05-21 at 8 20 08 pm](https://cloud.githubusercontent.com/assets/108163/15451468/c393ea0c-1f91-11e6-8260-2f1aa3460485.png)
