### PR TITLE
Observe for mutations after document onload

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,11 +4,6 @@ import Logger from "./logger";
 (function() {
   var logger = new Logger();
 
-  var load = function() {
-    window.removeEventListener("load", load, false);
-    auditor(document, logger);
-  };
-
   var observer = new MutationObserver(function(mutations) {
     mutations.forEach(function(mutation) {
       auditor(mutation.target, logger);
@@ -22,6 +17,11 @@ import Logger from "./logger";
     subtree: true
   };
 
+  var load = function() {
+    window.removeEventListener("load", load, false);
+    auditor(document, logger);
+    observer.observe(document, config);
+  };
+
   window.addEventListener("load", load);
-  observer.observe(document, config);
 })();


### PR DESCRIPTION
This patches the MutationObserver to not begin observing the document until after the full document audit which is run on window onload. 

When using accesslint in a local environment which had many DOM mutations prior to window.onload, the browser was slowed down by the mutation observer. Waiting until after the onload is complete helps with initial page load.

Addresses https://github.com/accesslint/accesslint.js/issues/20