### PR TITLE
Fixes to run with phantomjs

### DIFF
--- a/src/auditor.js
+++ b/src/auditor.js
@@ -10,5 +10,6 @@ export default function(target, logger) {
 
   window.axe.a11yCheck(target.parentNode, options, (results) => {
     report(results, logger);
+    window.AccessLint.results = results;
   });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,17 +3,9 @@ import Logger from "./logger";
 
 (function() {
   var logger = new Logger();
-
   var load = function() {
-    window.removeEventListener("load", load, false);
     auditor(document, logger);
   };
-
-  var observer = new MutationObserver(function(mutations) {
-    mutations.forEach(function(mutation) {
-      auditor(mutation.target, logger);
-    });
-  });
 
   var config = {
     attributes: true,
@@ -22,6 +14,7 @@ import Logger from "./logger";
     subtree: true
   };
 
+  window.AccessLint = {};
   window.addEventListener("load", load);
-  observer.observe(document, config);
+  window.addEventListener("accesslint:run", load);
 })();


### PR DESCRIPTION
- Mutation event observer was failing.
- Provide a hook to run the audit manually.
- Set results on the window object.